### PR TITLE
Fix preview handler prop in DocumentUpload

### DIFF
--- a/unstructured-platform-frontend/src/components/custom/DocumentUpload.tsx
+++ b/unstructured-platform-frontend/src/components/custom/DocumentUpload.tsx
@@ -18,7 +18,10 @@ const acceptedFileTypes: Accept = {
   'text/html': ['.html', '.htm'],
 };
 
-const DocumentUpload: React.FC<DocumentUploadProps> = ({ onFilesSelected }) => {
+const DocumentUpload: React.FC<DocumentUploadProps> = ({
+  onFilesSelected,
+  onPreviewFile,
+}) => {
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const [rejectedFiles, setRejectedFiles] = useState<FileRejection[]>([]);
   const [isUploading, setIsUploading] = useState<boolean>(false); // Placeholder for upload state


### PR DESCRIPTION
## Summary
- fix missing `onPreviewFile` prop in DocumentUpload component

## Testing
- `npm run lint` *(fails: next missing)*
- `npm run build` *(fails: Build failed because of webpack errors)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841006bbe08832fbf24e29761cdeedc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Preview" button for each selected file in the document upload interface, allowing users to preview files before uploading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->