### PR TITLE
Improve README and boolean helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,26 @@ This repository contains a simple FastAPI backend and a Next.js frontend used fo
 
 ## Backend
 
-The backend lives in `unstructured-platform-backend`. After installing the Python dependencies you can run it with:
+The backend lives in `unstructured-platform-backend`.
+Run the following to install dependencies and start the development server:
 
 ```bash
+cd unstructured-platform-backend
+pip install -r requirements.txt
 uvicorn main:app --reload
 ```
 
-The service exposes a basic health check at `/health` and a `/api/v1/process-document/` endpoint for uploading documents.
+This exposes a basic health check at `/health` and a `/api/v1/process-document/` endpoint for uploading documents.
 
 ## Frontend
 
 The Next.js application resides in `unstructured-platform-frontend`.
-After installing the Node dependencies with `npm install` you can start the dev server:
+Run the following to install dependencies and start the dev server:
 
 ```bash
+cd ../unstructured-platform-frontend
+npm install
 npm run dev
 ```
 
-The app will be available on <http://localhost:3000>.
+The app will be available at <http://localhost:3000>.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# rag
+# Unstructured Platform
+
+This repository contains a simple FastAPI backend and a Next.js frontend used for experimenting with retrieval augmented generation (RAG).
+
+## Backend
+
+The backend lives in `unstructured-platform-backend`. After installing the Python dependencies you can run it with:
+
+```bash
+uvicorn main:app --reload
+```
+
+The service exposes a basic health check at `/health` and a `/api/v1/process-document/` endpoint for uploading documents.
+
+## Frontend
+
+The Next.js application resides in `unstructured-platform-frontend`.
+After installing the Node dependencies with `npm install` you can start the dev server:
+
+```bash
+npm run dev
+```
+
+The app will be available on <http://localhost:3000>.

--- a/unstructured-platform-backend/app/api/routers/processing.py
+++ b/unstructured-platform-backend/app/api/routers/processing.py
@@ -77,8 +77,8 @@ async def process_document(
         # but for partition (auto), it's often tied to hi_res or specific handling.
         # We'll pass it if not None, unstructured handles if it's applicable.
         _pdf_infer_table_structure = string_to_bool(pdf_infer_table_structure)
-        if _pdf_infer_table_structure is not None: # Check if it was provided
-             partition_kwargs["pdf_infer_table_structure"] = _pdf_infer_table_structure
+        if _pdf_infer_table_structure is not None:  # Check if it was provided
+            partition_kwargs["pdf_infer_table_structure"] = _pdf_infer_table_structure
 
 
         if extract_image_block_types and extract_image_block_types.strip():

--- a/unstructured-platform-backend/app/api/routers/processing.py
+++ b/unstructured-platform-backend/app/api/routers/processing.py
@@ -5,12 +5,21 @@ from unstructured.chunking.basic import chunk_elements as chunk_elements_basic #
 from unstructured.cleaners.core import clean_extra_whitespace
 import tempfile
 import os
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Union
 
 router = APIRouter()
 
 # Helper to convert boolean form data
-def string_to_bool(value: str) -> bool:
+def string_to_bool(value: Union[str, bool, None]) -> Optional[bool]:
+    """Convert common truthy/falsey form values to ``bool``.
+
+    Returns ``None`` when ``value`` is ``None`` to make the conversion safe for
+    optional form fields.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
     return value.lower() == "true"
 
 # Pydantic model could be used here for better validation of Form data,


### PR DESCRIPTION
## Summary
- document how to run backend and frontend
- make `string_to_bool` more robust for optional values

## Testing
- `python -m py_compile unstructured-platform-backend/app/api/routers/processing.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68411a9b13a8832fa6897db5dc03b086

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Completely rewrote the README to provide a comprehensive project overview, setup instructions for both backend and frontend, and details on available API endpoints.

- **Bug Fixes**
  - Improved handling of optional boolean form fields in the backend, ensuring more robust processing of different input types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->