### PR TITLE
Fix DocumentUpload preview prop

### DIFF
--- a/unstructured-platform-frontend/src/components/custom/DocumentUpload.tsx
+++ b/unstructured-platform-frontend/src/components/custom/DocumentUpload.tsx
@@ -18,7 +18,10 @@ const acceptedFileTypes: Accept = {
   'text/html': ['.html', '.htm'],
 };
 
-const DocumentUpload: React.FC<DocumentUploadProps> = ({ onFilesSelected }) => {
+const DocumentUpload: React.FC<DocumentUploadProps> = ({
+  onFilesSelected,
+  onPreviewFile,
+}) => {
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const [rejectedFiles, setRejectedFiles] = useState<FileRejection[]>([]);
   const [isUploading, setIsUploading] = useState<boolean>(false); // Placeholder for upload state
@@ -81,7 +84,7 @@ const DocumentUpload: React.FC<DocumentUploadProps> = ({ onFilesSelected }) => {
           {isDragActive ? (
             <p className="text-center text-primary">Drop the files here ...</p>
           ) : (
-            <p className="text-center text-muted-foreground">Drag 'n' drop files here, or click to select files</p>
+            <p className="text-center text-muted-foreground">Drag &apos;n&apos; drop files here, or click to select files</p>
           )}
         </div>
 


### PR DESCRIPTION
## Summary
- ensure DocumentUpload component destructures and forwards `onPreviewFile`
- escape apostrophes in drag/drop helper text

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6841023e86e8832fa5aeb45874dd61ef