### PR TITLE
Register full processing router

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# rag
+# RAG Platform
+
+This repository contains a small example platform with a FastAPI backend and a Next.js frontend.
+
+## Backend API
+
+The backend lives in `unstructured-platform-backend`. It exposes two sets of processing routes:
+
+- `processing` – full document processing using the `unstructured` library, mounted under `/api/v1`.
+- `processing_simple` – a lightweight placeholder implementation, mounted under `/api/v1/simple`.
+
+Each router provides endpoints such as `/process-document/`, `/supported-formats` and `/health` within its prefix.
+
+## Frontend
+
+The frontend lives in `unstructured-platform-frontend` and is a standard Next.js application.

--- a/unstructured-platform-backend/main.py
+++ b/unstructured-platform-backend/main.py
@@ -1,10 +1,11 @@
 from fastapi import FastAPI
-from app.api.routers import processing_simple
+from app.api.routers import processing, processing_simple
 
 app = FastAPI()
 
 # Include routers
-app.include_router(processing_simple.router, prefix="/api/v1", tags=["processing"])
+app.include_router(processing.router, prefix="/api/v1", tags=["processing"])
+app.include_router(processing_simple.router, prefix="/api/v1/simple", tags=["processing_simple"])
 
 @app.get("/health")
 async def health_check():


### PR DESCRIPTION
## Summary
- add advanced processing router to FastAPI app
- mount the simple router under `/api/v1/simple`
- document both router prefixes in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684790908700832f841c663ba9370a73